### PR TITLE
Add error handling for corrupted layers

### DIFF
--- a/config/default.coffee
+++ b/config/default.coffee
@@ -6,9 +6,6 @@ getEnv = (name, defaultValue) ->
 	defaultValue
 
 module.exports =
-	features:
-		appVolume: false
-
 	mqtt:
 		host:     getEnv "MQTT_ENDPOINT", "localhost"
 		port:     getEnv "MQTT_PORT",     1883

--- a/config/test.coffee
+++ b/config/test.coffee
@@ -14,7 +14,10 @@ module.exports =
 			maxAttempts:    2
 			minWaitingTime: 1 * 100 # 0.5 second
 			maxWaitingTime: 1 * 100 # 0.5 second
+		registryAuth:
+			credentials: undefined
 
+	# @deprecated
 	groups:
 		fileLocation: path.resolve "meta", "groups.json"
 

--- a/src/Client.coffee
+++ b/src/Client.coffee
@@ -21,7 +21,7 @@ class Client extends EventEmitter
 		@subscribedTopics = []
 
 	isTLSEnabled: ->
-		every @options.tls
+		@options.tls and every @options.tls
 
 	constructURL: ->
 		protocol = "mqtt"

--- a/src/lib/Docker.coffee
+++ b/src/lib/Docker.coffee
@@ -87,7 +87,7 @@ class Docker extends EventEmitter
 				interval: ->
 					retryIn
 				errorFilter: (error) ->
-					return handleCorruptedLayer error if error.match /failed to register layer/i
+					return handleCorruptedLayer error if error.message.match /failed to register layer/i
 
 					debug "Downloading #{name} failed, error code: #{error.statusCode}"
 					return false unless error.statusCode in config.docker.retry.errorCodes

--- a/src/lib/Docker.coffee
+++ b/src/lib/Docker.coffee
@@ -293,8 +293,6 @@ class Docker extends EventEmitter
 		"app-layer-agent-@shared"
 
 	createSharedVolume: (name) ->
-		return unless config.features.appVolume
-
 		try
 			volume = await @dockerode.getVolume @getSharedVolumeName()
 			data   = await volume.inspect()
@@ -307,8 +305,6 @@ class Docker extends EventEmitter
 			await @dockerode.createVolume Name: @getSharedVolumeName()
 
 	createVolumeIfNotExists: (name) ->
-		return unless config.features.appVolume
-
 		try
 			volume = await @dockerode.getVolume @getVolumeName name
 			data   = await volume.inspect()

--- a/src/manager/AppUpdater.coffee
+++ b/src/manager/AppUpdater.coffee
@@ -51,8 +51,8 @@ class AppUpdater
 
 		@state.sendNsState
 			updateState:
-				type:    "idle"
-				message: "Idle"
+				short: "Idle"
+				long:  "Idle"
 
 		if updatesCount
 			log.info kleur.cyan "#{updatesCount} application(s) to update/remove"
@@ -77,9 +77,8 @@ class AppUpdater
 
 		@state.sendNsState
 			updateState:
-				type:        "update"
-				message:     "Updating applications ..."
-				description: message.join "\n"
+				short: "Updating applications ..."
+				long:  message.join "\n"
 
 		try
 			# Verifying authentication does not work properly for GitLab registries
@@ -91,16 +90,15 @@ class AppUpdater
 
 			@state.sendNsState
 				updateState:
-					type:    "idle"
-					message: "Idle"
+					short: "Idle"
+					long:  "Idle"
 		catch error
 			log.error kleur.yellow "Failed to update: #{error.message}"
 
 			@state.sendNsState
 				updateState:
-					type:        "error"
-					message:     "Update failed"
-					description: error.message
+					short: "ERROR"
+					long:  error.message
 		finally
 			@state.throttledSendState()
 
@@ -167,7 +165,7 @@ class AppUpdater
 
 	normalizeAppConfiguration: (appConfiguration) ->
 		{ containerName, mounts } = appConfiguration
-		mounts                    = @addVolumes containerName, mounts if appConfiguration.createVolumes
+		mounts                    = @addVolumes containerName, mounts if config.features.appVolume
 
 		name:         containerName
 		AttachStdin:  not appConfiguration.detached

--- a/src/manager/AppUpdater.coffee
+++ b/src/manager/AppUpdater.coffee
@@ -51,8 +51,8 @@ class AppUpdater
 
 		@state.sendNsState
 			updateState:
-				short: "Idle"
-				long:  "Idle"
+				type:    "idle"
+				message: "Idle"
 
 		if updatesCount
 			log.info kleur.cyan "#{updatesCount} application(s) to update/remove"
@@ -77,8 +77,9 @@ class AppUpdater
 
 		@state.sendNsState
 			updateState:
-				short: "Updating applications ..."
-				long:  message.join "\n"
+				type:        "update"
+				message:     "Updating applications ..."
+				description: message.join "\n"
 
 		try
 			# Verifying authentication does not work properly for GitLab registries
@@ -90,15 +91,16 @@ class AppUpdater
 
 			@state.sendNsState
 				updateState:
-					short: "Idle"
-					long:  "Idle"
+					type:    "idle"
+					message: "Idle"
 		catch error
 			log.error kleur.yellow "Failed to update: #{error.message}"
 
 			@state.sendNsState
 				updateState:
-					short: "ERROR"
-					long:  error.message
+					type:        "error"
+					message:     "Update failed"
+					description: error.message
 		finally
 			@state.throttledSendState()
 
@@ -165,7 +167,7 @@ class AppUpdater
 
 	normalizeAppConfiguration: (appConfiguration) ->
 		{ containerName, mounts } = appConfiguration
-		mounts                    = @addVolumes containerName, mounts if config.features.appVolume
+		mounts                    = @addVolumes containerName, mounts if appConfiguration.createVolumes
 
 		name:         containerName
 		AttachStdin:  not appConfiguration.detached

--- a/src/manager/AppUpdater.coffee
+++ b/src/manager/AppUpdater.coffee
@@ -81,7 +81,8 @@ class AppUpdater
 				long:  message.join "\n"
 
 		try
-			await @docker.verifyAuthentication() if @docker.isAuthenticationEnabled()
+			# Verifying authentication does not work properly for GitLab registries
+			# await @docker.verifyAuthentication() if @docker.isAuthenticationEnabled()
 			await @docker.removeUntaggedImages()
 			await @removeApps  appsToChange.remove
 			await @installApps appsToChange.install

--- a/src/manager/AppUpdater.coffee
+++ b/src/manager/AppUpdater.coffee
@@ -95,10 +95,16 @@ class AppUpdater
 		catch error
 			log.error kleur.yellow "Failed to update: #{error.message}"
 
-			@state.sendNsState
-				updateState:
-					short: "ERROR"
-					long:  error.message
+			if error.code is "ERR_CORRUPTED_LAYER"
+				@state.sendNsState
+					updateState:
+						short: "ERROR: Layer corrupted"
+						long:  error.message
+			else
+				@state.sendNsState
+					updateState:
+						short: "ERROR"
+						long:  error.message
 		finally
 			@state.throttledSendState()
 
@@ -165,7 +171,7 @@ class AppUpdater
 
 	normalizeAppConfiguration: (appConfiguration) ->
 		{ containerName, mounts } = appConfiguration
-		mounts                    = @addVolumes containerName, mounts if config.features.appVolume
+		mounts                    = @addVolumes containerName, mounts if appConfiguration.createVolumes
 
 		name:         containerName
 		AttachStdin:  not appConfiguration.detached

--- a/src/manager/AppUpdater.coffee
+++ b/src/manager/AppUpdater.coffee
@@ -81,6 +81,7 @@ class AppUpdater
 				long:  message.join "\n"
 
 		try
+			await @docker.verifyAuthentication() if @docker.isAuthenticationEnabled()
 			await @docker.removeUntaggedImages()
 			await @removeApps  appsToChange.remove
 			await @installApps appsToChange.install

--- a/src/manager/StateManager.coffee
+++ b/src/manager/StateManager.coffee
@@ -1,6 +1,5 @@
 { throttle, isString, isEqual, isPlainObject, map } = require "lodash"
 config                                              = require "config"
-{ promisify }                                       = require "util"
 
 pkg            = require "../../package.json"
 getIpAddresses = require "../helpers/getIPAddresses"
@@ -27,7 +26,7 @@ class StateManager
 			.join "/"
 			.replace /\/{2,}/, "/"
 
-		promisify(@socket.publish.bind @socket) topic, message, options.opts
+		@socket.publish topic, message, options.opts
 
 	sendStateToMqtt: =>
 		state       = await @generateStateObject()
@@ -47,7 +46,7 @@ class StateManager
 	sendAppStateToMqtt: =>
 		@publish
 			topic:   "nsState/containers"
-			message: await promisify(@docker.listContainers.bind @docker)()
+			message: await @docker.listContainers()
 
 	sendSystemStateToMqtt: =>
 		systemInfo = await @docker.getDockerInfo()

--- a/test/AppUpdater.test.coffee
+++ b/test/AppUpdater.test.coffee
@@ -240,3 +240,50 @@ describe ".AppUpdater", ->
 				RestartPolicy:
 					Name: "always"
 				PortBindings: {}
+
+	it "should not create volumes if they are not configured", ->
+		docker      = new Docker
+		updater     = new AppUpdater docker
+		appConfig   = updater.normalizeAppConfiguration
+			applicationName: testContainerName
+			containerName:   testContainerName
+			detached:        true
+			environment:     []
+			fromImage:       "hello-world"
+			mounts:          []
+			networkMode:     "host"
+			privileged:      false
+			restartPolicy:   "always"
+			version:         "^1.0.0"
+			labels:
+				"com.viriciti.applayer.agent": true
+				"com.viriciti.applayer.group": "manual"
+
+		assert.equal appConfig.HostConfig.Binds.length, 0
+
+	it "should create volumes if they are configured", ->
+		docker      = new Docker
+		updater     = new AppUpdater docker
+		appConfig   = updater.normalizeAppConfiguration
+			createVolumes:   true #
+			applicationName: testContainerName
+			containerName:   testContainerName
+			detached:        true
+			environment:     []
+			fromImage:       "hello-world"
+			mounts:          []
+			networkMode:     "host"
+			privileged:      false
+			restartPolicy:   "always"
+			version:         "^1.0.0"
+			labels:
+				"com.viriciti.applayer.agent": true
+				"com.viriciti.applayer.group": "manual"
+
+		regexInBinds = (regex) ->
+			appConfig.HostConfig.Binds.some (bind) ->
+				regex.test bind
+
+		assert.ok appConfig.HostConfig.Binds.length >= 2
+		assert.ok regexInBinds /\/data/
+		assert.ok regexInBinds /\/share/

--- a/test/AppUpdater.test.coffee
+++ b/test/AppUpdater.test.coffee
@@ -1,6 +1,6 @@
-assert                               = require "assert"
-{ random, identity, constant, take } = require "lodash"
-spy                                  = require "spy"
+assert                     = require "assert"
+{ random, constant, take } = require "lodash"
+spy                        = require "spy"
 
 AppUpdater   = require "../src/manager/AppUpdater"
 GroupManager = require "../src/manager/GroupManager"

--- a/test/AppUpdater.test.coffee
+++ b/test/AppUpdater.test.coffee
@@ -1,6 +1,6 @@
-assert     = require "assert"
-{ random } = require "lodash"
-spy        = require "spy"
+assert                               = require "assert"
+{ random, identity, constant, take } = require "lodash"
+spy                                  = require "spy"
 
 AppUpdater   = require "../src/manager/AppUpdater"
 GroupManager = require "../src/manager/GroupManager"
@@ -166,3 +166,77 @@ describe ".AppUpdater", ->
 
 		manager.updateGroups ["default"]
 		updater.handleCollection configurations
+
+	it "should be able to create a volume", ->
+		volumeName       = "hello-world"
+		sharedVolumeName = "share"
+		mockDocker       =
+			getVolumeName:       constant volumeName
+			getSharedVolumeName: constant sharedVolumeName
+
+		updater           = new AppUpdater mockDocker
+		mounts            = updater.addVolumes volumeName, []
+		mountsWithoutFlag = mounts.map (mount) ->
+			take(mount.split(":"), 2).join ":"
+
+		assert.ok mounts.length
+		assert.ok mountsWithoutFlag.includes [volumeName, "/data"].join ":"
+		assert.ok mountsWithoutFlag.includes [sharedVolumeName, "/share"].join ":"
+
+	it "should reserve /data and /share", ->
+		volumeName       = "hello-world"
+		sharedVolumeName = "share"
+		mockDocker       =
+			getVolumeName:       constant volumeName
+			getSharedVolumeName: constant sharedVolumeName
+
+		currentMounts     = ["abc:/data", "def:/share"]
+		updater           = new AppUpdater mockDocker
+		mounts            = updater.addVolumes volumeName, currentMounts
+		mountsWithoutFlag = mounts.map (mount) ->
+			take(mount.split(":"), 2).join ":"
+
+		assert.equal mounts.length, 2
+		assert.ok mountsWithoutFlag.includes [volumeName, "/data"].join ":"
+		assert.ok mountsWithoutFlag.includes [sharedVolumeName, "/share"].join ":"
+
+	it "should be able to normalize application configuration", ->
+		docker      = new Docker
+		updater     = new AppUpdater docker
+		randomValue = random Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER
+		appConfig   = updater.normalizeAppConfiguration
+			applicationName: testContainerName
+			containerName:   testContainerName
+			detached:        true
+			environment:     []
+			fromImage:       "hello-world"
+			mounts:          ["/this/will/never/exist/ok/#{randomValue}:/version/mount"]
+			networkMode:     "host"
+			privileged:      false
+			restartPolicy:   "always"
+			version:         "^1.0.0"
+			labels:
+				"com.viriciti.applayer.agent": true
+				"com.viriciti.applayer.group": "manual"
+
+		# Reference: https://docs.docker.com/engine/api/v1.25/#operation/ContainerCreate
+		assert.deepEqual appConfig,
+			name:         testContainerName
+			AttachStdin:  false
+			AttachStdout: false
+			AttachStderr: false
+			Image:        "hello-world"
+			Env: [
+				"APP_LAYER_PRIVILEGED=false"
+				"APP_LAYER_DETACHED=true"
+			]
+			Labels:
+				"com.viriciti.applayer.agent": true
+				"com.viriciti.applayer.group": "manual"
+			HostConfig:
+				Binds:       ["/this/will/never/exist/ok/#{randomValue}:/version/mount"]
+				NetworkMode: "host"
+				Privileged:  false
+				RestartPolicy:
+					Name: "always"
+				PortBindings: {}

--- a/test/AppUpdater.test.coffee
+++ b/test/AppUpdater.test.coffee
@@ -139,7 +139,7 @@ describe ".AppUpdater", ->
 
 		updater.handleCollection configurations
 
-	it.only "should return last known configurations if queueing an update without arguments", (done) ->
+	it "should return last known configurations if queueing an update without arguments", (done) ->
 		@timeout 3000
 
 		mockDocker                        = createSharedVolume: -> Promise.resolve()

--- a/test/Client.test.coffee
+++ b/test/Client.test.coffee
@@ -108,8 +108,8 @@ describe ".Client", ->
 		client.connect()
 
 		forked     = client.fork()
-		expected   = ["packetreceive", "error", "reconnect", "offline"]
-		nameInList = (name) -> name in Object.keys forked._client._events
+		expected   = ["packetreceive", "reconnect", "offline"]
+		nameInList = (name) -> name in Object.keys client.mqtt._client._events
 
 		forked
 			.once "connect", ->

--- a/test/Docker.test.coffee
+++ b/test/Docker.test.coffee
@@ -123,7 +123,7 @@ describe ".Docker", ->
 
 		assert.rejects ->
 			docker.pullImage "hello-world"
-		, /corrupted layer/
+		, /layer corrupted/i
 
 	it "should be able to return a shortened image id", ->
 		docker    = new Docker
@@ -165,9 +165,8 @@ describe ".Docker", ->
 
 			docker.listContainers()
 
-	it "should check for authentication", ->
+	it.skip "should check for authentication", ->
 		docker = new Docker
-		return @skip() unless docker.isAuthenticationEnabled()
 
 		credentials = clone config.docker.registryAuth.credentials
 		invalid     = { ...credentials, username: "this-does-not-exist", password: "*****" }

--- a/test/Docker.test.coffee
+++ b/test/Docker.test.coffee
@@ -123,7 +123,7 @@ describe ".Docker", ->
 
 		assert.rejects ->
 			docker.pullImage "hello-world"
-		, /layer corrupted/i
+		, /corrupted layer/i
 
 	it "should be able to return a shortened image id", ->
 		docker    = new Docker

--- a/test/TaskManager.test.coffee
+++ b/test/TaskManager.test.coffee
@@ -1,9 +1,9 @@
-RPC                              = require "mqtt-json-rpc"
-assert                           = require "assert"
-config                           = require "config"
-mosca                            = require "mosca"
-mqtt                             = require "mqtt"
-{ random, first, isPlainObject } = require "lodash"
+RPC                                    = require "mqtt-json-rpc"
+assert                                 = require "assert"
+config                                 = require "config"
+mosca                                  = require "mosca"
+mqtt                                   = require "mqtt"
+{ random, first, isPlainObject, noop } = require "lodash"
 
 registerFunction = require "../src/helpers/registerFunction"
 
@@ -69,6 +69,8 @@ describe ".TaskManager", ->
 			fn:     thenable()
 			name:   "hello-world"
 			params: ["b"]
+
+		noop
 
 	it "should sort tasks in the order of arrival", ->
 		manager     = new TaskManager client
@@ -137,6 +139,7 @@ describe ".TaskManager", ->
 			fn:     thenable 100
 			name:   "hello-world"
 			params: ["a"]
+		noop
 
 	it "should add an error status if a task fails", (done) ->
 		manager    = new TaskManager client
@@ -156,3 +159,4 @@ describe ".TaskManager", ->
 			fn:     -> Promise.reject error
 			name:   "hello-world"
 			params: ["a"]
+		noop

--- a/test/utils/container.coffee
+++ b/test/utils/container.coffee
@@ -26,7 +26,7 @@ createTestContainer = (options) ->
 	, options
 
 	if options.useNative
-		await docker.dockerClient.createContainer
+		await docker.dockerode.createContainer
 			name:  name
 			Image: "hello-world"
 	else
@@ -34,7 +34,7 @@ createTestContainer = (options) ->
 			name:  name
 			Image: "hello-world"
 
-	container        = docker.dockerClient.getContainer name
+	container        = docker.dockerode.getContainer name
 	containers[name] = container
 
 	if options.autoStart


### PR DESCRIPTION
This pull requests adds an extra case for handling corrupted layers.
Instead of a generic `ERROR` label, it replaces it with an `ERROR: Layer corrupted` label with a tooltip showing what layer is corrupted.