### PR TITLE
Feature/misconfigured log driver

### DIFF
--- a/src/lib/Docker.coffee
+++ b/src/lib/Docker.coffee
@@ -227,6 +227,7 @@ class Docker extends EventEmitter
 			running:  containerInfo.State.Running
 			health:   containerInfo.State.Health?.Status
 		ports:          containerInfo.HostConfig.PortBindings
+		logDriver:      containerInfo.HostConfig.LogConfig.Type
 		environment:    containerInfo.Config.Env
 		sizeFilesystem: containerInfo.SizeRw          # in bytes
 		sizeRootFilesystem: containerInfo.SizeRootFs # in bytes
@@ -346,6 +347,12 @@ class Docker extends EventEmitter
 			error.code     = "ERR_AUTH_INCORRECT"
 			error.original = original
 
+			throw error
+
+	getSystemInfo: ->
+		try
+			await @dockerode.info()
+		catch error
 			throw error
 
 module.exports = Docker

--- a/src/manager/AppUpdater.coffee
+++ b/src/manager/AppUpdater.coffee
@@ -105,7 +105,7 @@ class AppUpdater
 			m
 		, []
 
-		if apps.length
+		if appsToDelete.length
 			log.warn "Apps using incorrect log driver: #{(map appsToDelete, "name").join ", "}"
 		else
 			log.info "No misconfigured apps"

--- a/src/manager/AppUpdater.coffee
+++ b/src/manager/AppUpdater.coffee
@@ -94,10 +94,10 @@ class AppUpdater
 		omit currentApps, map appsToDelete, "name"
 
 	accountForMisconfiguredLogDriver: (currentApps) ->
+		systemInfo   = await @docker.getSystemInfo()
 		appsToDelete = reduce currentApps, (m, container, name) ->
 			id         = container.id
 			logDriver  = container.logDriver
-			systemInfo = await @docker.getSystemInfo()
 
 			if logDriver isnt systemInfo.LoggingDriver
 				log.warn "App `#{name}` is using different log driver `#{logDriver}` than system has configured: `#{systemInfo.LoggingDriver}`. Scheduled for removal and recreation.."


### PR DESCRIPTION
This feature branch allows App Layer Agent to recreate containers that are using a different log driver than the Docker daemon is using. This will ensure that the Docker daemon is always able to read the logs for the containers.